### PR TITLE
Add app usage display after device registration

### DIFF
--- a/android/app/src/main/kotlin/com/example/hrishikesh/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/hrishikesh/MainActivity.kt
@@ -6,19 +6,32 @@ import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
+// For retrieving app usage statistics
+import com.example.hrishikesh.UsageStatsHelper
+
 class MainActivity: FlutterActivity() {
     private val CHANNEL = "parent_control/device"
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
-                call, result ->
-            if (call.method == "getDeviceId") {
-                val androidId = Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID)
-                result.success(androidId)
-            } else {
-                result.notImplemented()
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "getDeviceId" -> {
+                    val androidId = Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID)
+                    result.success(androidId)
+                }
+                "getUsageStats" -> {
+                    val usageList = UsageStatsHelper.getUsageStats(this)
+                    val mapped = usageList.map { usage ->
+                        mapOf(
+                            "packageName" to usage.packageName,
+                            "usage" to usage.totalTimeForeground
+                        )
+                    }
+                    result.success(mapped)
+                }
+                else -> result.notImplemented()
             }
         }
     }

--- a/lib/models/app_usage.dart
+++ b/lib/models/app_usage.dart
@@ -1,0 +1,14 @@
+class AppUsage {
+  final String packageName;
+  final Duration usage;
+
+  AppUsage({required this.packageName, required this.usage});
+
+  factory AppUsage.fromMap(Map<dynamic, dynamic> map) {
+    final int millis = map['usage'] ?? 0;
+    return AppUsage(
+      packageName: map['packageName'] ?? '',
+      usage: Duration(milliseconds: millis),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- model Android app usage data
- expose `getUsageStats` method over method channel
- fetch app usage in home screen
- render usage list in descending order after device registration

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ec400d20832da18226b0f0f037df