### PR TITLE
Add app name and icon to usage stats

### DIFF
--- a/android/app/src/main/kotlin/com/example/hrishikesh/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/hrishikesh/MainActivity.kt
@@ -26,7 +26,9 @@ class MainActivity: FlutterActivity() {
                     val mapped = usageList.map { usage ->
                         mapOf(
                             "packageName" to usage.packageName,
-                            "usage" to usage.totalTimeForeground
+                            "usage" to usage.totalTimeForeground,
+                            "appName" to usage.appName,
+                            "icon" to usage.icon
                         )
                     }
                     result.success(mapped)

--- a/lib/models/app_usage.dart
+++ b/lib/models/app_usage.dart
@@ -1,14 +1,23 @@
 class AppUsage {
   final String packageName;
   final Duration usage;
+  final String appName;
+  final String icon;
 
-  AppUsage({required this.packageName, required this.usage});
+  AppUsage({
+    required this.packageName,
+    required this.usage,
+    required this.appName,
+    required this.icon,
+  });
 
   factory AppUsage.fromMap(Map<dynamic, dynamic> map) {
     final int millis = map['usage'] ?? 0;
     return AppUsage(
       packageName: map['packageName'] ?? '',
       usage: Duration(milliseconds: millis),
+      appName: map['appName'] ?? '',
+      icon: map['icon'] ?? '',
     );
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:android_intent_plus/android_intent.dart';
+import 'dart:convert';
 import '../services/api_service.dart';
 import '../models/app_usage.dart';
 
@@ -182,7 +183,11 @@ class _HomeScreenState extends State<HomeScreen> {
                             (u.usage.inMinutes - hours * 60).toString().padLeft(2, '0');
                         final duration = '${hours.toString().padLeft(2, '0')}:$minutes';
                         return ListTile(
-                          title: Text(u.packageName),
+                          leading: CircleAvatar(
+                            backgroundImage: MemoryImage(base64Decode(u.icon)),
+                          ),
+                          title: Text(u.appName),
+                          subtitle: Text(u.packageName),
                           trailing: Text(duration),
                         );
                       },


### PR DESCRIPTION
## Summary
- enrich `AppUsageInfo` with app name and icon
- send the new fields via the platform channel
- parse and display app name and icon in Flutter

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6868f8d49a58832d801c46aeee76760d