### PR TITLE
Add date selector for app usage

### DIFF
--- a/android/app/src/main/kotlin/com/example/hrishikesh/AppMonitoringService.kt
+++ b/android/app/src/main/kotlin/com/example/hrishikesh/AppMonitoringService.kt
@@ -21,7 +21,7 @@ class AppMonitoringService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val usageList = UsageStatsHelper.getUsageStats(this)
+        val usageList = UsageStatsHelper.getUsageStats(this, null)
         for (app in usageList) {
             Log.d("AppUsage", "Package: ${app.packageName}, Time: ${app.totalTimeForeground / 1000} sec")
         }

--- a/android/app/src/main/kotlin/com/example/hrishikesh/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/hrishikesh/MainActivity.kt
@@ -22,7 +22,8 @@ class MainActivity: FlutterActivity() {
                     result.success(androidId)
                 }
                 "getUsageStats" -> {
-                    val usageList = UsageStatsHelper.getUsageStats(this)
+                    val dateMillis = call.argument<Long>("dateMillis")
+                    val usageList = UsageStatsHelper.getUsageStats(this, dateMillis)
                     val mapped = usageList.map { usage ->
                         mapOf(
                             "packageName" to usage.packageName,

--- a/android/app/src/main/kotlin/com/example/hrishikesh/UsageStatsHelper.kt
+++ b/android/app/src/main/kotlin/com/example/hrishikesh/UsageStatsHelper.kt
@@ -41,19 +41,22 @@ object UsageStatsHelper {
         return mode == AppOpsManager.MODE_ALLOWED
     }
 
-    fun getUsageStats(context: Context): List<AppUsageInfo> {
+    fun getUsageStats(context: Context, dateMillis: Long?): List<AppUsageInfo> {
         val usageStatsList = ArrayList<AppUsageInfo>()
 
         val usageStatsManager =
             context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
 
         val calendar = Calendar.getInstance()
-        val endTime = calendar.timeInMillis
+        if (dateMillis != null && dateMillis > 0) {
+            calendar.timeInMillis = dateMillis
+        }
         calendar.set(Calendar.HOUR_OF_DAY, 0)
         calendar.set(Calendar.MINUTE, 0)
         calendar.set(Calendar.SECOND, 0)
         calendar.set(Calendar.MILLISECOND, 0)
         val startTime = calendar.timeInMillis
+        val endTime = startTime + 24L * 60 * 60 * 1000
 
         val stats: List<UsageStats> = usageStatsManager.queryUsageStats(
             UsageStatsManager.INTERVAL_DAILY,


### PR DESCRIPTION
## Summary
- enable date-based querying of usage stats on Android native side
- expose selected date in main app
- fetch usage based on chosen date and update UI

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690efdc59c832dbcb34754d7d0ea8f