### PR TITLE
Document usage access permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,20 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Usage Access Permission
+
+This application reads app usage statistics on Android devices. Android
+requires users to manually grant the **Usage Access** permission before any
+usage data can be retrieved. If this permission is not granted you may see log
+messages similar to:
+
+```
+W/UsageStatsHelper: No usage data found. Is permission granted?
+```
+
+When launching the app for the first time you will be redirected to the
+"Usage Access" settings screen. Locate **hrishikesh** in that list and toggle
+**Allow usage access** to **ON**. Once enabled, restart the app and usage data
+should start appearing in the logs (for example:
+`UsageStatsHelper: Fetched 25 usage entries`).

--- a/android/app/src/main/kotlin/com/example/hrishikesh/UsageStatsHelper.kt
+++ b/android/app/src/main/kotlin/com/example/hrishikesh/UsageStatsHelper.kt
@@ -67,6 +67,7 @@ object UsageStatsHelper {
         val pm = context.packageManager
 
         if (stats.isNotEmpty()) {
+            Log.d("UsageStatsHelper", "Fetched ${stats.size} usage entries")
             for (usage in stats) {
                 if (usage.totalTimeInForeground > 0) {
                     try {


### PR DESCRIPTION
## Summary
- add documentation describing how to enable Usage Access
- log the number of usage entries fetched

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686910f74f94832d968a5169bfc1e0d2