### PR TITLE
Show usage for missing packages

### DIFF
--- a/android/app/src/main/kotlin/com/example/hrishikesh/UsageStatsHelper.kt
+++ b/android/app/src/main/kotlin/com/example/hrishikesh/UsageStatsHelper.kt
@@ -92,6 +92,23 @@ object UsageStatsHelper {
                         )
                     } catch (e: PackageManager.NameNotFoundException) {
                         Log.w("UsageStatsHelper", "Package not found: ${usage.packageName}")
+                        val drawable = pm.defaultActivityIcon
+                        val bitmap: Bitmap = if (drawable is BitmapDrawable) {
+                            drawable.bitmap
+                        } else {
+                            drawable.toBitmap()
+                        }
+                        val stream = ByteArrayOutputStream()
+                        bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+                        val encoded = Base64.encodeToString(stream.toByteArray(), Base64.NO_WRAP)
+                        usageStatsList.add(
+                            AppUsageInfo(
+                                packageName = usage.packageName,
+                                totalTimeForeground = usage.totalTimeInForeground,
+                                appName = usage.packageName,
+                                icon = encoded
+                            )
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- include apps without package info in usage stats

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686913a3263c832dbdbe33f8197bb910