### PR TITLE
Add installed apps screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,16 @@ When launching the app for the first time you will be redirected to the
 **Allow usage access** to **ON**. Once enabled, restart the app and usage data
 should start appearing in the logs (for example:
 `UsageStatsHelper: Fetched 25 usage entries`).
+
+## Installed Apps View
+
+The home screen now features a **+** button that opens a new page
+displaying all installed applications on the device (excluding packages
+starting with `com.android`). Applications are grouped into the following
+categories:
+
+- Entertainment
+- Gaming
+- Education
+- Social
+- Other

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:android_intent_plus/android_intent.dart';
 import 'dart:convert';
 import '../services/api_service.dart';
 import '../models/app_usage.dart';
+import 'installed_apps_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -254,6 +255,16 @@ class _HomeScreenState extends State<HomeScreen> {
             ]
           ],
         ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const InstalledAppsScreen()),
+          );
+        },
+        tooltip: 'Installed Apps',
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/screens/installed_apps_screen.dart
+++ b/lib/screens/installed_apps_screen.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:device_apps/device_apps.dart';
+
+class InstalledAppsScreen extends StatefulWidget {
+  const InstalledAppsScreen({super.key});
+
+  @override
+  State<InstalledAppsScreen> createState() => _InstalledAppsScreenState();
+}
+
+class _InstalledAppsScreenState extends State<InstalledAppsScreen> {
+  final Map<String, List<Application>> _categorizedApps = {
+    'Entertainment': [],
+    'Gaming': [],
+    'Education': [],
+    'Social': [],
+    'Other': [],
+  };
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadApps();
+  }
+
+  Future<void> _loadApps() async {
+    List<Application> apps = await DeviceApps.getInstalledApplications(
+      includeSystemApps: true,
+      includeAppIcons: true,
+    );
+
+    apps = apps
+        .where((app) => !app.packageName.startsWith('com.android'))
+        .toList();
+
+    for (final app in apps) {
+      final cat = _mapCategory(app);
+      _categorizedApps[cat]?.add(app);
+    }
+
+    setState(() {
+      _isLoading = false;
+    });
+  }
+
+  String _mapCategory(Application app) {
+    if (app is ApplicationWithIcon) {
+      final category = app.category;
+      if (category != null) {
+        switch (category) {
+          case ApplicationCategory.game:
+            return 'Gaming';
+          case ApplicationCategory.audio:
+          case ApplicationCategory.video:
+          case ApplicationCategory.image:
+            return 'Entertainment';
+          case ApplicationCategory.social:
+            return 'Social';
+          case ApplicationCategory.education:
+            return 'Education';
+          default:
+            break;
+        }
+      }
+    }
+
+    final name = app.appName.toLowerCase();
+    if (name.contains('game')) return 'Gaming';
+    if (name.contains('edu')) return 'Education';
+    if (name.contains('music') ||
+        name.contains('video') ||
+        name.contains('movie') ||
+        name.contains('tv')) {
+      return 'Entertainment';
+    }
+    if (name.contains('facebook') ||
+        name.contains('whatsapp') ||
+        name.contains('twitter') ||
+        name.contains('chat') ||
+        name.contains('social') ||
+        name.contains('instagram')) {
+      return 'Social';
+    }
+    return 'Other';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Installed Apps')),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              children: _categorizedApps.entries.map((entry) {
+                if (entry.value.isEmpty) return const SizedBox.shrink();
+                return ExpansionTile(
+                  title: Text(entry.key),
+                  children: entry.value.map((app) {
+                    return ListTile(
+                      leading: app is ApplicationWithIcon
+                          ? Image.memory(app.icon, width: 32, height: 32)
+                          : null,
+                      title: Text(app.appName),
+                      subtitle: Text(app.packageName),
+                    );
+                  }).toList(),
+                );
+              }).toList(),
+            ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   shared_preferences: ^2.2.2
   android_intent_plus: ^4.0.1
   device_info_plus: ^9.1.1
+  device_apps: ^2.2.0
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add `device_apps` dependency
- create InstalledAppsScreen to list installed apps
- open the screen from a new `+` button on the home screen
- document feature in README

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68691c178090832d806c98245173ec07