### PR TITLE
Fix device_apps namespace

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.LibraryExtension
+
 allprojects {
     repositories {
         google()
@@ -14,6 +16,16 @@ subprojects {
 }
 subprojects {
     project.evaluationDependsOn(":app")
+}
+
+subprojects {
+    afterEvaluate {
+        if (name == "device_apps") {
+            extensions.findByType<LibraryExtension>()?.apply {
+                namespace = "com.example.device_apps"
+            }
+        }
+    }
 }
 
 tasks.register<Delete>("clean") {


### PR DESCRIPTION
## Summary
- configure `device_apps` library namespace when building Android

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68691ddc0b0c832d88125495df60be1a