### PR TITLE
Fix Gradle afterEvaluate error

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -19,9 +19,9 @@ subprojects {
 }
 
 subprojects {
-    afterEvaluate {
-        if (name == "device_apps") {
-            extensions.findByType<LibraryExtension>()?.apply {
+    if (name == "device_apps") {
+        plugins.withId("com.android.library") {
+            extensions.configure<LibraryExtension> {
                 namespace = "com.example.device_apps"
             }
         }


### PR DESCRIPTION
## Summary
- update `android/build.gradle.kts` to configure the `device_apps` plugin without
  calling `afterEvaluate`, avoiding the `Cannot run Project.afterEvaluate(Action)` error.

## Testing
- ❌ `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68691f5bb838832dac3d149e57d12ea2