### PR TITLE
Fix app category build error

### DIFF
--- a/lib/screens/installed_apps_screen.dart
+++ b/lib/screens/installed_apps_screen.dart
@@ -57,8 +57,6 @@ class _InstalledAppsScreenState extends State<InstalledAppsScreen> {
             return 'Entertainment';
           case ApplicationCategory.social:
             return 'Social';
-          case ApplicationCategory.education:
-            return 'Education';
           default:
             break;
         }


### PR DESCRIPTION
## Summary
- remove obsolete `ApplicationCategory.education` branch

## Testing
- `flutter test` *(fails: `bash: flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6869208d8848832db41e529ff54eb9ee