### PR TITLE
Improve installed apps filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,17 @@ should start appearing in the logs (for example:
 ## Installed Apps View
 
 The home screen now features a **+** button that opens a new page
-displaying all installed applications on the device (excluding packages
-starting with `com.android`). Applications are grouped into the following
-categories:
+displaying all user installed applications on the device. Android system
+packages (for example those starting with `com.android` or
+`com.google.android`) are filtered out automatically. Applications are
+grouped into the following categories:
 
 - Entertainment
 - Gaming
 - Education
 - Social
 - Other
+
+Social apps include popular messengers such as **WhatsApp**, **Telegram**,
+**Instagram**, and **LinkedIn**. Entertainment covers streaming services like
+**Hotstar**, **Netflix**, and similar apps.

--- a/lib/screens/installed_apps_screen.dart
+++ b/lib/screens/installed_apps_screen.dart
@@ -26,12 +26,16 @@ class _InstalledAppsScreenState extends State<InstalledAppsScreen> {
 
   Future<void> _loadApps() async {
     List<Application> apps = await DeviceApps.getInstalledApplications(
-      includeSystemApps: true,
+      includeSystemApps: false,
       includeAppIcons: true,
+      onlyAppsWithLaunchIntent: true,
     );
 
     apps = apps
-        .where((app) => !app.packageName.startsWith('com.android'))
+        .where((app) =>
+            !app.packageName.startsWith('com.android') &&
+            !app.packageName.startsWith('com.google.android') &&
+            !(app is Application ? (app.systemApp ?? false) : false))
         .toList();
 
     for (final app in apps) {
@@ -69,15 +73,26 @@ class _InstalledAppsScreenState extends State<InstalledAppsScreen> {
     if (name.contains('music') ||
         name.contains('video') ||
         name.contains('movie') ||
-        name.contains('tv')) {
+        name.contains('tv') ||
+        name.contains('netflix') ||
+        name.contains('hotstar') ||
+        name.contains('youtube') ||
+        name.contains('prime') ||
+        name.contains('spotify')) {
       return 'Entertainment';
     }
     if (name.contains('facebook') ||
         name.contains('whatsapp') ||
+        name.contains('telegram') ||
         name.contains('twitter') ||
         name.contains('chat') ||
         name.contains('social') ||
-        name.contains('instagram')) {
+        name.contains('instagram') ||
+        name.contains('linkedin') ||
+        name.contains('truecaller') ||
+        name.contains('snapchat') ||
+        name.contains('messenger') ||
+        name.contains('discord')) {
       return 'Social';
     }
     return 'Other';


### PR DESCRIPTION
## Summary
- filter out system apps when listing installed packages
- expand entertainment and social app detection
- document app categories in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692394ff54832d8565d96197910b71