### PR TITLE
Show all apps with default icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ should start appearing in the logs (for example:
 The home screen now features a **+** button that opens a new page
 displaying all user installed applications on the device. Android system
 packages (for example those starting with `com.android` or
-`com.google.android`) are filtered out automatically. Applications are
+`com.google.android`) are filtered out automatically. Applications without a
+launcher icon are still shown using a default Android symbol. Apps are
 grouped into the following categories:
 
 - Entertainment

--- a/lib/screens/installed_apps_screen.dart
+++ b/lib/screens/installed_apps_screen.dart
@@ -28,7 +28,9 @@ class _InstalledAppsScreenState extends State<InstalledAppsScreen> {
     List<Application> apps = await DeviceApps.getInstalledApplications(
       includeSystemApps: false,
       includeAppIcons: true,
-      onlyAppsWithLaunchIntent: true,
+      // Include apps even if they do not expose a launch intent so that
+      // non-launchable user installed packages are also visible.
+      onlyAppsWithLaunchIntent: false,
     );
 
     apps = apps
@@ -113,7 +115,7 @@ class _InstalledAppsScreenState extends State<InstalledAppsScreen> {
                     return ListTile(
                       leading: app is ApplicationWithIcon
                           ? Image.memory(app.icon, width: 32, height: 32)
-                          : null,
+                          : const Icon(Icons.android),
                       title: Text(app.appName),
                       subtitle: Text(app.packageName),
                     );


### PR DESCRIPTION
## Summary
- include packages without launcher intent in installed apps list
- show default icon when app icon missing
- document new behavior in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686925a809b0832d8b8fe976f5c43f5f