### PR TITLE
Display all non-system apps with default icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ should start appearing in the logs (for example:
 ## Installed Apps View
 
 The home screen now features a **+** button that opens a new page
-displaying all user installed applications on the device. Android system
-packages (for example those starting with `com.android` or
-`com.google.android`) are filtered out automatically. Applications without a
-launcher icon are still shown using a default Android symbol. Apps are
+displaying all user installed applications on the device. System
+packages are excluded automatically, while all other apps - including
+preinstalled Google applications - are listed. Applications without a
+launcher icon are shown using a default Android symbol. Apps are
 grouped into the following categories:
 
 - Entertainment

--- a/lib/screens/installed_apps_screen.dart
+++ b/lib/screens/installed_apps_screen.dart
@@ -35,8 +35,6 @@ class _InstalledAppsScreenState extends State<InstalledAppsScreen> {
 
     apps = apps
         .where((app) =>
-            !app.packageName.startsWith('com.android') &&
-            !app.packageName.startsWith('com.google.android') &&
             !(app is Application ? (app.systemApp ?? false) : false))
         .toList();
 


### PR DESCRIPTION
## Summary
- show all non-system apps without filtering by Android or Google package prefixes
- document updated behaviour in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686926de98f0832da45bdb187a0f176c